### PR TITLE
feat(dialog): async coordinator; ADK timeout+fallback; logging; layering

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
 
   # Static type checker to match CI "mypy --strict"
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.2
+    rev: v1.17.1
     hooks:
       - id: mypy
         pass_filenames: false

--- a/docs/0907/next.md
+++ b/docs/0907/next.md
@@ -1,0 +1,125 @@
+# Next.js フロントエンド開発手順書
+
+このドキュメントは、「AIレビューパネル」のフロントエンド開発に関するセットアップ手順、アーキテクチャ設計、および実装計画を記録するものです。
+
+## 1. 開発環境のセットアップ
+
+`pnpm` を用いて Next.js プロジェクトを新規に作成します。
+
+### 1.1 Next.jsプロジェクトの初期化
+
+以下のコマンドを実行して、`frontend` ディレクトリにプロジェクトを作成します。
+
+```bash
+pnpm dlx create-next-app@latest frontend --typescript --tailwind --eslint --app --use-pnpm --import-alias "@/*"
+```
+
+- **`frontend`**: プロジェクトディレクトリ名
+- **`--typescript`**: TypeScript を使用
+- **`--tailwind`**: Tailwind CSS を使用
+- **`--eslint`**: ESLint を使用
+- **`--app`**: App Router を使用
+- **`--use-pnpm`**: パッケージマネージャーとして `pnpm` を指定
+- **`--import-alias "@/*"`**: `@/*` のインポートエイリアスを設定
+
+### 1.2 ディレクトリ構成
+
+プロジェクトの初期化後、アプリケーションの要件に合わせて以下のディレクトリとファイルを作成します。
+
+```
+frontend/
+├── app/
+│   ├── layout.tsx                # 全体のレイアウト
+│   ├── page.tsx                  # 1. レビュー依頼ページ
+│   └── reviews/
+│       └── [id]/                 # 動的ルート
+│           ├── page.tsx          # 2. レビュー詳細ページ
+│           └── summary/
+│               └── page.tsx      # 3. 共有サマリーページ
+├── components/
+│   ├── PrdInputForm.tsx          # PRD入力フォーム
+│   ├── ReviewFocusView.tsx       # フォーカスモードのメインUI
+│   ├── IssueCard.tsx             # 個別の指摘事項を表示するカード
+│   ├── ChatWindow.tsx            # AIとの対話UI
+│   ├── SuggestionBox.tsx         # 修正案の表示・適用UI
+│   └── LoadingSpinner.tsx        # ローディング表示
+├── lib/
+│   └── api.ts                    # APIクライアント (fetchをラップ)
+└── store/
+    └── useReviewStore.ts         # 状態管理 (Zustand)
+```
+
+## 2. 主要コンポーネントの役割
+
+各コンポーネントは `prd.md` の要件に基づき、以下の役割を担います。
+
+-   **`PrdInputForm.tsx`**:
+    -   PRDを入力する大きなテキストエリアと「レビュー開始」ボタンを持つ、レビュー依頼ページ (`/`) のメインコンポーネント。
+    -   ボタンクリックで `POST /reviews` APIを呼び出し、取得した `review_id` を使ってレビュー詳細ページ (`/reviews/[id]`) へリダイレクトさせます。
+
+-   **`ReviewFocusView.tsx`**:
+    -   レビュー詳細ページ (`/reviews/[id]`) のメインコンポーネント。
+    -   `GET /reviews/[id]` APIを定期的にポーリングし、レビューが完了するのを待ちます。
+    -   レビュー完了後、取得した指摘事項 (`issues`) のリストを状態管理ストアに保存します。
+    -   状態管理ストアから現在のインデックス (`currentIssueIndex`) を参照し、対応する指摘事項を `IssueCard` コンポーネントとして一つだけ表示します。
+
+-   **`IssueCard.tsx`**:
+    -   一つの指摘事項（論点）に関する全ての情報を表示・操作するコンテナです。
+    -   指摘者、指摘内容、元のテキストなどを表示します。
+    -   `ChatWindow` や `SuggestionBox` を子コンポーネントとして持ちます。
+    -   「対応済み」「あとで」ボタンを持ち、クリックされると状態管理ストアのインデックスを更新し、次のカードを表示させます。
+
+-   **`ChatWindow.tsx`**:
+    -   AIとの対話を行うためのUI。`issue_id` と質問内容を `/dialog` APIに送信し、結果をリアルタイムで表示します。
+
+-   **`SuggestionBox.tsx`**:
+    -   AIからの修正案を表示し、適用するためのUI。「修正案を提案して」ボタンで `/suggest` APIを呼び出し、提案内容と「適用する」ボタンを表示します。「適用する」ボタンで `/apply_suggestion` APIを呼び出します。
+
+## 3. 状態管理とデータフロー
+
+複数のページやコンポーネントでレビューセッションの状態を共有するため、状態管理ライブラリ **Zustand** を導入します (`store/useReviewStore.ts`)。
+
+### 3.1 管理する主要な状態
+
+-   `reviewId` (string | null): 現在のレビューセッションID。
+-   `prdText` (string): ユーザーが入力した、またはAIによって更新されたPRDの原文。
+-   `issues` (Array): AIからの指摘事項のリスト。
+-   `currentIssueIndex` (number): `issues`リストの中で現在表示している指摘のインデックス。
+-   `issueStatuses` (Object): 各`issue`のステータス（例: `{'ISSUE-001': 'done'}`）。
+
+### 3.2 データフロー
+
+アプリケーション内のデータの流れは以下のようになります。
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Frontend
+    participant API
+    participant Zustand Store
+
+    User->>Frontend: 1. PRD入力 & レビュー開始
+    Frontend->>API: POST /reviews
+    API-->>Frontend: { review_id }
+    Frontend->>Zustand Store: review_idを保存
+    Frontend->>User: 2. /reviews/[id] へ遷移 & ポーリング開始
+
+    loop ポーリング
+        Frontend->>API: GET /reviews/[id]
+        API-->>Frontend: { status: 'completed', issues: [...] }
+    end
+
+    Frontend->>Zustand Store: 3. issuesリストを保存
+    Zustand Store-->>Frontend: 最新のissuesをコンポーネントに提供
+    Frontend->>User: 4. 最初の論点カードを表示
+
+    User->>Frontend: 5. 対話、修正案適用など
+    Frontend->>API: POST /dialog など
+    API-->>Frontend: 応答
+    Frontend->>User: UIを更新
+
+    User->>Frontend: 6. 「対応済み」クリック
+    Frontend->>Zustand Store: 7. currentIssueIndexをインクリメント
+    Zustand Store-->>Frontend: 次のissueをコンポーネントに提供
+    Frontend->>User: 8. 次の論点カードを表示
+```

--- a/docs/250906/scope.md
+++ b/docs/250906/scope.md
@@ -85,11 +85,11 @@
 ### **Week 1: AIコアエンジンの完成とAPIコントラクトの確定**
 **目標:** AIが価値あるレビューを生成できることを技術的に証明し、フロントエンドチームが開発を開始できるモックAPIを完成させる。
 
--   [ ] **1. 開発環境のセットアップ**
+-   [x] **1. 開発環境のセットアップ**
     -   [x] 1.1 Gitリポジトリの作成とブランチ戦略の合意
-    -   [ ] 1.2 Python (`uv`) / Node.js (`npm`) 開発環境のセットアップ
-    -   [ ] 1.3 依存パッケージ定義 (`pyproject.toml`, `package.json`)
-    -   [x] 1.4 LLM APIキーの共有と `.env` ファイルでの管理
+    -   [x] 1.2 Python (`uv`) / Node.js (`npm`) 開発環境のセットアップ（`uv`導入、CI整備）
+    -   [x] 1.3 依存パッケージ定義（`pyproject.toml` で `fastapi`, `google-adk`, `pytest` 等を管理）
+    -   [x] 1.4 LLM APIキーの共有と `.env` ファイルでの管理（`.env.example` 提供）
 -   [ ] **2. AIコアエンジンの開発と単体テスト (ADK)**
     -   [x] 2.1 Pydanticモデルの定義 (`adk_app/schemas.py`)
         -   **Done:** `IssueItem`, `SpecialistOutput`, `FinalIssue`, `ReviewSessionForTool` の4つのPydanticモデルがコードとして定義されていること。
@@ -116,28 +116,28 @@
             -   **Done:** コマンドが成功し、ブラウザでADKのテスト用Web UIが表示されること。
         -   [ ] 2.5.3 Web UIからテスト用のPRDテキストを送信し、最終的なレビュー結果がJSONとして表示されることを確認する。
             -   **Done:** `structure_review_results`ツールが呼び出されたログが出力され、最終的な`ReviewSessionForTool`形式のJSONがUI上に表示されること。
--   [ ] **3. Web APIのモック実装 (FastAPI)**
-    -   [ ] 3.1 FastAPIプロジェクトの基本セットアップとディレクトリ構成の決定 (`app/`以下)
-    -   [ ] 3.2 `architecture.md`のAPI仕様に基づき、全5エンドポイントのI/Oを`app/schemas.py`で定義
-    -   [ ] 3.3 全エンドポイントを、AIを呼ばずにダミーのJSONデータを返すモックとして実装
-    -   [ ] 3.4 Next.jsからのアクセスを許可するためのCORS設定
+-   [x] **3. Web APIのモック実装 (FastAPI)**
+    -   [x] 3.1 FastAPIプロジェクトの基本セットアップとディレクトリ構成（`src/hibikasu_agent/api` 配下に`main.py`/`routers/`）
+    -   [x] 3.2 `architecture.md`のAPI仕様に基づき、主要エンドポイントのI/Oを定義（`src/hibikasu_agent/api/schemas.py`）
+    -   [x] 3.3 `/reviews` 系をモック/インメモリで実装（`api/services/mock.py`/`api/services/ai.py`）
+    -   [x] 3.4 CORS設定（`api/main.py` に `CORSMiddleware` と環境変数許可）
 
 ---
 
 ### **Week 2: APIの本実装とフロントエンドの基本フロー完成**
 **目標:** フロントエンドとバックエンドを結合し、「フォーカスモード」によるPRDレビューの一連の体験がWebアプリケーション上で完結する。
 
--   [ ] **4. APIの本実装とAIエンジンの結合**
-    -   [ ] 4.1 FastAPIの`lifespan`と依存性注入のセットアップ
-        -   **Done:** `app/lifespan.py`, `app/dependencies.py`が作成され、`app/main.py`に組み込まれていること。
-    -   [ ] 4.2 `run_ai_review_service`を実装し、`POST /reviews`を本実装に差し替え
-        -   **Done:** `app/services.py`にADKの`Runner`を呼び出すロジックが実装され、APIがそれを非同期タスクとして実行できること。
+-   [x] **4. APIの本実装とAIエンジンの結合**
+    -   [x] 4.1 FastAPIの`lifespan`による起動時初期化
+        -   **Done:** `src/hibikasu_agent/api/main.py` で ADKエージェントを初期化し、サービス層に注入。
+    -   [x] 4.2 ADK Runner によるレビュー実行とポーリング
+        -   **Done:** `api/main.py` で `Runner`+`InMemorySessionService` を用い1ターン実行し、結果をセッションstateから取得。`POST /reviews` → BGタスク → `GET /reviews/{id}` で完了取得。
     -   [ ] 4.3 対話API (`/dialog`) の実装
         -   **Done:** `architecture.md`の設計通り、担当AI特定と動的プロンプト生成ロジックが実装され、`SpecialistAgent`を呼び出して応答を返せること。
     -   [ ] 4.4 提案・適用API (`/suggest`, `/apply_suggestion`) の実装
         -   **Done:** 各エンドポイントがそれぞれの責務（提案生成、PRD原文の更新）を果たすロジックが実装されていること。
-    -   [ ] 4.5 APIの自動E2Eテストの実装
-        -   **Done:** `pytest`+`httpx`で、レビュー開始から完了までのAPIフローを検証するテストコードが実装され、CIで成功すること。
+    -   [x] 4.5 APIの自動E2Eテストの実装
+        -   **Done:** `pytest`+`fastapi.TestClient` で、レビュー開始から完了までのAPIフローを検証（`tests/api/test_reviews_endpoints.py` ほか）。CI成功。
 -   [ ] **5. フロントエンド開発 (Next.js)**
     -   [ ] 5.1 Next.js (App Router, TypeScript, Tailwind CSS) でのプロジェクトセットアップ
         -   **Done:** `create-next-app`が完了し、`tailwind.config.js`等の設定ファイルが正しく構成されていること。
@@ -169,11 +169,11 @@
         -   **Done:** Figmaのデザインやチームで合意したスタイルガイドに沿って、UIが実装されていること。
     -   [ ] 7.4 エラーハンドリング強化
         -   **Done:** APIエラー時に、アプリケーションがクラッシュせず、ユーザーに適切なエラーメッセージが表示されること。
--   [ ] **8. AIバックエンドの改善**
-    -   [ ] 8.1 プロンプトのチューニング
-        -   **Done:** 複数パターンのPRDで動作確認し、指摘の質や形式に問題があれば`prompts.toml`を修正し、改善が見られることを確認する。
-    -   [ ] 8.2 指摘の統合・優先順位付けロジックの改善
-        -   **Done:** `structure_review_results`ツールのソートロジック等を見直し、より妥当な順序で指摘が表示されるようにコードを修正する。
+-   [x] **8. AIバックエンドの改善**
+    -   [x] 8.1 プロンプトのチューニング
+        -   **Done:** `prompts/agents.toml` に出力仕様（JSON/High|Mid|Low等）と判定基準を追記し安定化。
+    -   [x] 8.2 指摘の統合・優先順位付けロジックの改善
+        -   **Done:** 集約ツール（`agents/parallel_orchestrator/tools.py`）で重み付け/整列。入力のseverity揺れをサーバ側で正規化（`schemas/models.py`）。
 -   [ ] **9. 最終デモ準備**
     -   [ ] 9.1 デモ用のPRDと発表シナリオの完成
         -   **Done:** デモで話す内容、見せる画面、操作する手順がドキュメント化されていること。

--- a/scripts/try_api.py
+++ b/scripts/try_api.py
@@ -53,6 +53,24 @@ def main():
                 print("✨ Final Issues:")
                 # 結果を綺麗に表示
                 print(json.dumps(data, indent=2, ensure_ascii=False))
+
+                # --- 3. POST /dialog on the first issue ---
+                issues = data.get("issues") or []
+                if issues:
+                    first_issue = issues[0]
+                    issue_id = first_issue.get("issue_id")
+                    q = "この論点の背景と対策の優先度を簡潔に教えてください"
+                    print("\n🗣️  3. Asking dialog about the first issue...")
+                    dj = requests.post(
+                        f"{BASE_URL}/reviews/{review_id}/issues/{issue_id}/dialog",
+                        headers=headers,
+                        data=json.dumps({"question_text": q}),
+                    )
+                    if dj.ok:
+                        print("💬 Dialog response:")
+                        print(json.dumps(dj.json(), indent=2, ensure_ascii=False))
+                    else:
+                        print(f"❌ Dialog failed: {dj.status_code} {dj.text}")
                 return
 
             if status == "failed":

--- a/src/hibikasu_agent/api/__init__.py
+++ b/src/hibikasu_agent/api/__init__.py
@@ -7,7 +7,7 @@ submodule file.
 
 from __future__ import annotations
 
-from .services import ai as ai_services
+from hibikasu_agent.services import runtime as ai_services
 
 __all__ = [
     "ai_services",

--- a/src/hibikasu_agent/api/main.py
+++ b/src/hibikasu_agent/api/main.py
@@ -7,12 +7,8 @@ from typing import Any
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from hibikasu_agent.agents.parallel_orchestrator.agent import (
-    create_parallel_review_agent,
-)
-from hibikasu_agent.api import ai_services
 from hibikasu_agent.api.routers.reviews import router as reviews_router
-from hibikasu_agent.api.schemas import Issue as ApiIssue
+from hibikasu_agent.services.providers.adk import install_default_review_impl
 from hibikasu_agent.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -42,91 +38,8 @@ async def lifespan(app: FastAPI):  # type: ignore[no-untyped-def]
     except Exception as _err:
         _ = _err
 
-    # Default: unconditionally inject ADK-backed review implementation
-    try:
-        logger.info("Initializing ADK parallel review agent (default)")
-        model_name = os.getenv("ADK_MODEL") or "gemini-2.0-flash"
-        agent = create_parallel_review_agent(model=model_name)
-        app.state.adk_parallel_review_agent = agent
-
-        def _adk_review_impl(prd_text: str) -> list[ApiIssue]:
-            """Run ADK pipeline via Runner and return API Issue list.
-
-            Uses InMemorySessionService and a one-off session. The merger agent writes
-            FinalIssuesResponse under output_key "final_review_issues" in session state.
-            """
-            try:
-                import asyncio
-                from uuid import uuid4
-
-                from google.adk.runners import Runner
-                from google.adk.sessions import InMemorySessionService
-                from google.genai import types as genai_types
-
-                async def _run_once() -> list[dict]:
-                    service = InMemorySessionService()
-                    app_name = "hibikasu_review_api"
-                    user_id = f"api_user_{uuid4()}"
-                    session_id = f"sess_{uuid4()}"
-
-                    # Create session
-                    await service.create_session(app_name=app_name, user_id=user_id, session_id=session_id)
-
-                    runner = Runner(agent=agent, app_name=app_name, session_service=service)
-
-                    # Send PRD text as a single user message
-                    content = genai_types.Content(role="user", parts=[genai_types.Part(text=str(prd_text))])
-
-                    # Drain events until final; ignore intermediate
-                    async for _event in runner.run_async(user_id=user_id, session_id=session_id, new_message=content):
-                        pass
-
-                    # Read aggregator output from session state
-                    sess = await service.get_session(app_name=app_name, user_id=user_id, session_id=session_id)
-                    state = getattr(sess, "state", {}) if sess else {}
-                    out = state.get("final_review_issues") or {}
-                    final_issues: list[dict] = []
-                    if isinstance(out, dict) and isinstance(out.get("final_issues"), list):
-                        final_issues = list(out.get("final_issues") or [])
-                    return final_issues
-
-                final_issues = asyncio.run(_run_once())
-
-                api_issues: list[ApiIssue] = []
-                for item in final_issues:
-                    try:
-                        api_issues.append(
-                            ApiIssue(
-                                issue_id=str(item.get("issue_id") or ""),
-                                priority=int(item.get("priority") or 0),
-                                agent_name=str(item.get("agent_name") or "unknown"),
-                                comment=str(item.get("comment") or ""),
-                                original_text=str(item.get("original_text") or ""),
-                            )
-                        )
-                    except Exception as err:  # validation error on a single item
-                        logger.warning("Skipping invalid ADK issue: %s | data=%s", err, item)
-                return api_issues
-            except Exception as err:
-                # Try to surface nested ExceptionGroup/TaskGroup details if present
-                detail = str(err)
-                sub = getattr(err, "exceptions", None)
-                if isinstance(sub, list | tuple) and sub:
-                    detail = f"{detail} | first_sub={sub[0]}"
-                logger.error("ADK review execution failed: %s", detail)
-                return [
-                    ApiIssue(
-                        issue_id="AI-ERROR",
-                        priority=1,
-                        agent_name="AI-Orchestrator",
-                        comment=f"ADK実行に失敗しました: {detail}",
-                        original_text=str(prd_text)[:120] or "(empty)",
-                    )
-                ]
-
-        ai_services.set_review_impl(_adk_review_impl)
-    except Exception as err:
-        logger.error("Failed to initialize ADK review integration: %s", err)
+    # Default: delegate ADK-backed review installation to providers layer
+    install_default_review_impl(app)
 
     yield
 

--- a/src/hibikasu_agent/api/services/__init__.py
+++ b/src/hibikasu_agent/api/services/__init__.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import cast
 
-from hibikasu_agent.api.services import ai as ai_service
 from hibikasu_agent.api.services.base import ReviewService
+from hibikasu_agent.services import runtime as ai_service
 
 
 def get_service() -> ReviewService:

--- a/src/hibikasu_agent/services/__init__.py
+++ b/src/hibikasu_agent/services/__init__.py
@@ -1,0 +1,12 @@
+"""Application service layer package.
+
+This package contains:
+- runtime: in-memory state + orchestration hooks used by the API layer
+- providers: concrete engines (ADK, mock) that plug into the runtime
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "runtime",
+]

--- a/src/hibikasu_agent/services/providers/__init__.py
+++ b/src/hibikasu_agent/services/providers/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+"""Providers for review execution (ADK, mock, etc.)."""

--- a/src/hibikasu_agent/services/providers/adk.py
+++ b/src/hibikasu_agent/services/providers/adk.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from hibikasu_agent.api.schemas import Issue as ApiIssue
+from hibikasu_agent.services import runtime as runtime_services
+from hibikasu_agent.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Module-level holders for chat support (avoid global statements)
+_coordinator_agent_holder: list[Any | None] = [None]
+_chat_session_service_holder: list[Any | None] = [None]
+
+
+def install_default_review_impl(app: Any) -> None:  # noqa: PLR0915
+    """Initialize ADK review agent and install as runtime review impl.
+
+    This keeps FastAPI app assembly thin; the concrete logic stays here.
+    """
+    try:
+        from hibikasu_agent.agents.parallel_orchestrator.agent import (
+            create_coordinator_agent,
+            create_parallel_review_agent,
+        )
+
+        model_name = os.getenv("ADK_MODEL") or "gemini-2.0-flash"
+        logger.info("Initializing ADK parallel review agent", extra={"model": model_name})
+        agent = create_parallel_review_agent(model=model_name)
+        app.state.adk_parallel_review_agent = agent
+        # Coordinator for dialog routing among specialists
+        _coordinator_agent_holder[0] = create_coordinator_agent(model=model_name)
+        app.state.adk_coordinator_agent = _coordinator_agent_holder[0]
+
+        def _adk_review_impl(prd_text: str) -> list[ApiIssue]:
+            try:
+                import asyncio
+                from uuid import uuid4
+
+                from google.adk.runners import Runner
+                from google.adk.sessions import InMemorySessionService
+                from google.genai import types as genai_types
+
+                async def _run_once() -> tuple[list[dict], dict]:
+                    service = InMemorySessionService()
+                    app_name = "hibikasu_review_api"
+                    user_id = f"api_user_{uuid4()}"
+                    session_id = f"sess_{uuid4()}"
+
+                    await service.create_session(app_name=app_name, user_id=user_id, session_id=session_id)
+                    runner = Runner(agent=agent, app_name=app_name, session_service=service)
+
+                    content = genai_types.Content(role="user", parts=[genai_types.Part(text=str(prd_text))])
+                    async for _event in runner.run_async(user_id=user_id, session_id=session_id, new_message=content):
+                        pass
+
+                    sess = await service.get_session(app_name=app_name, user_id=user_id, session_id=session_id)
+                    state = getattr(sess, "state", {}) if sess else {}
+                    out = state.get("final_review_issues") or {}
+                    final_issues: list[dict] = []
+                    if isinstance(out, dict) and isinstance(out.get("final_issues"), list):
+                        final_issues = list(out.get("final_issues") or [])
+                    # Return both final_issues and full state for fallback/diagnostics
+                    return final_issues, state
+
+                # Apply timeout to avoid hanging background tasks
+                timeout_s = float(os.getenv("ADK_REVIEW_TIMEOUT_SEC", "40"))
+                logger.info("ADK review run start", extra={"timeout_s": timeout_s})
+                final_issues, state = asyncio.run(asyncio.wait_for(_run_once(), timeout=timeout_s))
+                logger.info(
+                    "ADK review run done",
+                    extra={
+                        "final_issues": len(final_issues),
+                        "state_keys": list(state.keys()) if isinstance(state, dict) else None,
+                    },
+                )
+
+                # Fallback: if merger didn't populate final_issues, aggregate locally
+                if not final_issues and isinstance(state, dict):
+                    try:
+                        from hibikasu_agent.agents.parallel_orchestrator.tools import (
+                            aggregate_final_issues,
+                        )
+
+                        logger.info("Falling back to local aggregation from specialist outputs")
+                        agg = aggregate_final_issues(
+                            prd_text=str(prd_text),
+                            engineer_issues=state.get("engineer_issues"),
+                            ux_designer_issues=state.get("ux_designer_issues"),
+                            qa_tester_issues=state.get("qa_tester_issues"),
+                            pm_issues=state.get("pm_issues"),
+                        )
+                        if isinstance(agg, dict) and isinstance(agg.get("final_issues"), list):
+                            final_issues = list(agg["final_issues"])
+                            logger.info("Local aggregation produced issues", extra={"count": len(final_issues)})
+                    except Exception as agg_err:
+                        logger.error("Local aggregation failed", extra={"error": str(agg_err)})
+
+                api_issues: list[ApiIssue] = []
+                for item in final_issues:
+                    try:
+                        api_issues.append(
+                            ApiIssue(
+                                issue_id=str(item.get("issue_id") or ""),
+                                priority=int(item.get("priority") or 0),
+                                agent_name=str(item.get("agent_name") or "unknown"),
+                                comment=str(item.get("comment") or ""),
+                                original_text=str(item.get("original_text") or ""),
+                            )
+                        )
+                    except Exception as err:  # validation error on a single item
+                        logger.warning("Skipping invalid ADK issue: %s | data=%s", err, item)
+                return api_issues
+            except Exception as err:
+                # Surface nested ExceptionGroup/TaskGroup details if present
+                detail = str(err)
+                sub = getattr(err, "exceptions", None)
+                if isinstance(sub, list | tuple) and sub:
+                    detail = f"{detail} | first_sub={sub[0]}"
+                logger.error("ADK review execution failed", extra={"detail": detail})
+                return [
+                    ApiIssue(
+                        issue_id="AI-ERROR",
+                        priority=1,
+                        agent_name="AI-Orchestrator",
+                        comment=f"ADK実行に失敗しました: {detail}",
+                        original_text=str(prd_text)[:120] or "(empty)",
+                    )
+                ]
+
+        runtime_services.set_review_impl(_adk_review_impl)
+    except Exception as err:
+        logger.error("Failed to initialize ADK review integration", extra={"error": str(err)})
+
+
+async def answer_dialog(review_id: str, issue_id: str, question_text: str) -> str:
+    """Answer a follow-up question about a specific issue via coordinator agent.
+
+    Falls back to a heuristic response if ADK is unavailable.
+    """
+    try:
+        issue = runtime_services.find_issue(review_id, issue_id)
+        if issue is None:
+            return "該当する論点が見つかりませんでした。"
+
+        coord = _coordinator_agent_holder[0]
+        if coord is None:
+            # ADK not initialized; fallback response
+            return (
+                f"（簡易回答）『{issue.original_text}』に関するご質問: {question_text}\n"
+                "まずは仕様の明確化と簡潔な対策の合意が有効です。"
+            )
+
+        # Lazy init shared session service to accumulate dialog history per issue
+        cs = _chat_session_service_holder[0]
+        if cs is None:
+            from google.adk.sessions import InMemorySessionService
+
+            cs = InMemorySessionService()
+            _chat_session_service_holder[0] = cs
+
+        from google.adk.runners import Runner
+        from google.genai import types as genai_types
+
+        # Compose runtime context (instruction is owned by coordinator agent via TOML)
+        prompt = (
+            f"- 担当領域の目安: {issue.agent_name}\n"
+            f"- PRD抜粋: {issue.original_text}\n"
+            f"- 指摘: {issue.comment}\n\n"
+            f"ユーザーの質問: {question_text}"
+        )
+
+        session_id = f"dialog_{review_id}_{issue_id}"
+        app_name = "hibikasu_review_api"
+
+        async def _run_once() -> str:
+            # Ensure session exists (create if missing)
+            from contextlib import suppress
+
+            with suppress(Exception):
+                await cs.create_session(app_name=app_name, user_id="dialog_user", session_id=session_id)
+
+            runner = Runner(agent=coord, app_name=app_name, session_service=cs)
+            content = genai_types.Content(role="user", parts=[genai_types.Part(text=prompt)])
+
+            final_text = ""
+            async for event in runner.run_async(user_id="dialog_user", session_id=session_id, new_message=content):
+                if (
+                    getattr(event, "is_final_response", lambda: False)()
+                    and getattr(event, "content", None)
+                    and event.content.parts
+                ):
+                    final_text = event.content.parts[0].text or ""
+            return final_text or "回答を生成できませんでした。"
+
+        return await _run_once()
+    except Exception as err:
+        logger.error("Dialog execution failed", extra={"error": str(err)})
+        return "（簡易回答）現在うまく回答できません。時間を置いて再度お試しください。"

--- a/src/hibikasu_agent/services/runtime.py
+++ b/src/hibikasu_agent/services/runtime.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import time
+import uuid
+from collections.abc import Callable
+from typing import Any, cast
+
+from hibikasu_agent.api.schemas import Issue
+from hibikasu_agent.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# In-memory store for review sessions (API-compatible shape)
+reviews_in_memory: dict[str, dict[str, Any]] = {}
+
+# Pluggable review implementation for testing/injection.
+# Signature: (prd_text: str) -> list[Issue]
+_review_impl_holder: list[Callable[[str], list[Issue]] | None] = [None]
+
+
+def set_review_impl(func: Callable[[str], list[Issue]] | None) -> None:
+    _review_impl_holder[0] = func
+
+
+def has_review_impl() -> bool:
+    return _review_impl_holder[0] is not None
+
+
+def new_review_session(prd_text: str, panel_type: str | None = None) -> str:
+    review_id = str(uuid.uuid4())
+    reviews_in_memory[review_id] = {
+        "created_at": time.time(),
+        "status": "processing",
+        "issues": None,
+        "prd_text": prd_text,
+        "panel_type": panel_type,
+        "polls": 0,
+    }
+    logger.info(
+        "new_review_session created",
+        extra={
+            "review_id": review_id,
+            "panel_type": panel_type or "",
+            "prd_len": len(prd_text or ""),
+        },
+    )
+    return review_id
+
+
+def _default_review_impl(prd_text: str) -> list[Issue]:
+    return [
+        Issue(
+            issue_id="AI-001",
+            priority=1,
+            agent_name="AI-Orchestrator",
+            comment="自動レビュー（暫定）: 仕様の曖昧さに注意してください。",
+            original_text=prd_text[:80] or "(empty)",
+        )
+    ]
+
+
+def get_review_session(review_id: str) -> dict[str, Any]:
+    data = reviews_in_memory.get(review_id)
+    if not data:
+        return {"status": "not_found", "issues": None}
+
+    data["polls"] = int(data.get("polls", 0)) + 1
+    logger.debug(
+        "poll review_session",
+        extra={"review_id": review_id, "polls": data["polls"], "status": data.get("status")},
+    )
+    if data["polls"] <= 1:
+        return {"status": "processing", "issues": None}
+
+    return {"status": data.get("status", "processing"), "issues": data.get("issues")}
+
+
+def find_issue(review_id: str, issue_id: str) -> Issue | None:
+    session = reviews_in_memory.get(review_id)
+    if not session or not session.get("issues"):
+        return None
+    issues: list[Issue] = cast("list[Issue]", session["issues"])  # populated by compute
+    for issue in issues:
+        if issue.issue_id == issue_id:
+            return issue
+    return None
+
+
+def kickoff_compute(review_id: str) -> None:
+    """Compute issues for a review_id synchronously.
+
+    Intended to be scheduled via FastAPI BackgroundTasks to avoid blocking requests.
+    """
+    data = reviews_in_memory.get(review_id)
+    if not data:
+        return
+    if data.get("issues") is not None:
+        return
+    try:
+        logger.info("kickoff_compute starting", extra={"review_id": review_id})
+        impl = _review_impl_holder[0] or _default_review_impl
+        issues = impl(str(data.get("prd_text", "")))
+        data["issues"] = issues
+        data["status"] = "completed"
+        logger.info(
+            "kickoff_compute completed",
+            extra={"review_id": review_id, "issues_count": len(issues) if issues else 0},
+        )
+    except Exception as _err:
+        data["status"] = "failed"
+        data["error"] = str(_err)
+        logger.error("kickoff_compute failed", extra={"review_id": review_id, "error": str(_err)})

--- a/tests/api/test_dialog_endpoint.py
+++ b/tests/api/test_dialog_endpoint.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+from hibikasu_agent.api.main import app
+
+
+def test_issue_dialog_returns_response_text():
+    client = TestClient(app)
+
+    # Start review and get review_id
+    res = client.post("/reviews", json={"prd_text": "テストPRD（対話テスト）"})
+    assert res.status_code == 200
+    review_id = res.json()["review_id"]
+
+    # First poll: processing
+    r1 = client.get(f"/reviews/{review_id}")
+    assert r1.status_code == 200
+
+    # Second poll: completed with issues from injected impl
+    r2 = client.get(f"/reviews/{review_id}")
+    assert r2.status_code == 200
+    body = r2.json()
+    assert body["status"] == "completed"
+    issue_id = body["issues"][0]["issue_id"]
+
+    # Ask dialog
+    q = "この論点の背景を教えてください"
+    dj = client.post(
+        f"/reviews/{review_id}/issues/{issue_id}/dialog",
+        json={"question_text": q},
+    )
+    assert dj.status_code == 200
+    data = dj.json()
+    assert "response_text" in data and isinstance(data["response_text"], str)
+    assert data["response_text"] != ""
+
+
+def test_issue_dialog_returns_404_when_issue_not_found():
+    client = TestClient(app)
+
+    # Start review
+    res = client.post("/reviews", json={"prd_text": "テストPRD（対話404）"})
+    review_id = res.json()["review_id"]
+
+    # Ensure session exists by polling once
+    client.get(f"/reviews/{review_id}")
+
+    # Use a non-existent issue id
+    dj = client.post(
+        f"/reviews/{review_id}/issues/NO_SUCH_ISSUE/dialog",
+        json={"question_text": "存在しない論点？"},
+    )
+    assert dj.status_code == 404

--- a/tests/api/test_reviews_endpoints.py
+++ b/tests/api/test_reviews_endpoints.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+from hibikasu_agent.api.main import app
+
+
+def test_post_reviews_and_poll_until_completed():
+    client = TestClient(app)
+
+    # Start a review
+    res = client.post("/reviews", json={"prd_text": "テストPRD"})
+    assert res.status_code == 200
+    review_id = res.json()["review_id"]
+    assert isinstance(review_id, str) and review_id
+
+    # First poll -> processing
+    r1 = client.get(f"/reviews/{review_id}")
+    assert r1.status_code == 200
+    body1 = r1.json()
+    assert body1["status"] in ("processing", "completed")
+
+    # Second poll -> should be completed with issues from injected impl
+    r2 = client.get(f"/reviews/{review_id}")
+    assert r2.status_code == 200
+    body2 = r2.json()
+    assert body2["status"] == "completed"
+    assert isinstance(body2.get("issues"), list)
+    assert len(body2["issues"]) >= 1
+    assert body2["issues"][0]["issue_id"] == "TST-1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,40 @@
-"""Pytest configuration and fixtures."""
+"""Pytest configuration and fixtures.
+
+Ensure tests do not call external LLMs by injecting a deterministic
+AI review implementation for the duration of each test. This keeps
+tests fast, stable, and offline-friendly while exercising the API
+flow and background task polling logic.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import pytest
+from hibikasu_agent.api import ai_services
+
+
+@pytest.fixture(autouse=True)
+def inject_fake_ai_impl() -> Generator[None, None, None]:
+    """Auto-inject a fake AI review implementation for all tests.
+
+    Returns a single deterministic issue using the API schema, so the
+    service layer stores and returns predictable data.
+    """
+
+    def impl(prd_text: str):
+        return [
+            ai_services.Issue(
+                issue_id="TST-1",
+                priority=1,
+                agent_name="AI-Orchestrator",
+                comment="fake review",
+                original_text=prd_text,
+            )
+        ]
+
+    ai_services.set_review_impl(impl)
+    try:
+        yield
+    finally:
+        ai_services.set_review_impl(None)


### PR DESCRIPTION
This PR adds production-ready dialog support via the coordinator agent, hardens the ADK review path, and layers the implementation to keep `api/main.py` thin.

Highlights
- Dialog (async):
  - `services/providers/adk.py::answer_dialog` is now async and executed with the ADK coordinator agent.
  - Keeps issue-specific chat history using a shared `InMemorySessionService` (per `review_id`+`issue_id`).
- ADK review hardening:
  - Adds timeout (`ADK_REVIEW_TIMEOUT_SEC`, default 40s) using `asyncio.wait_for`.
  - Fallback local aggregation when merger did not populate `final_review_issues` (uses the same `aggregate_final_issues`).
  - Rich logging for start/done/error with state keys and counts.
- Layering / structure:
  - Move runtime to `src/hibikasu_agent/services/runtime.py` (in-memory sessions, kickoff, impl injection hook).
  - Add `services/providers/adk.py` for all ADK-specific logic and injection (`install_default_review_impl`).
  - `api/main.py` only calls `install_default_review_impl(app)` in lifespan.
- Router update:
  - `/reviews/{review_id}/issues/{issue_id}/dialog` now awaits `answer_dialog`.
- Developer UX:
  - `scripts/try_api.py` now asks dialog after review completion and prints the response.
  - Logging added in runtime for session creation/poll/compute.

CI
- Pre-commit updated to mypy v1.17.1 to avoid an upstream crash on Python 3.12.
- All hooks (ruff/bandit/mypy/pip-audit) pass locally.
- Test suite: 11 passed.

Notes
- Coordinator instruction remains in agent definitions / TOML; runtime only injects dynamic context (original_text, comment, question).
- If needed we can further expose dialog via providers to enable mocking in tests, but for now API-level tests assert shape only.
